### PR TITLE
Adds flexible color sets

### DIFF
--- a/modules/_color.scss
+++ b/modules/_color.scss
@@ -5,7 +5,7 @@
 
 @import '../util/index';
 
-@include build-colors($colors);
+@include build-colors($colorsets);
 @include build-greyscale($greyscale);
 
 @for $i from 0 through 10 {

--- a/modules/_color.scss
+++ b/modules/_color.scss
@@ -5,27 +5,8 @@
 
 @import '../util/index';
 
-@include build-colors($color-primary, 'primary');
-@include build-colors($color-secondary, 'secondary');
-@include build-colors($color-error, 'error');
-@include build-colors($color-warning, 'warning');
-@include build-colors($color-success, 'success');
-
-@each $grey in $greys {
-  $i: index($greys, $grey);
-
-  @if $i == 1 {
-    .cg-black { color: $black; }
-    .cg-white { color: $white; }
-    .cbgg-black { background-color: $black; }
-    .cbgg-white { background-color: $white; }
-  }
-
-  // The use of g here notes that these colors are a part of
-  // the greys that are generated
-  .cg-#{$i} { color: $grey; }
-  .cbgg-#{$i} { background-color: $grey; }
-}
+@include build-colors($colors);
+@include build-greyscale($greyscale);
 
 @for $i from 0 through 10 {
   .a-#{$i} { opacity: $i/10; }

--- a/modules/_style.scss
+++ b/modules/_style.scss
@@ -14,35 +14,3 @@
   'shadow': (box-shadow, $shadows),
   'rounded': (border-radius, $border-radii)
 ));
-
-
-// ============================================================================
-// Refactor Source
-// ----------------------------------------------------------------------------
-.b-black { border: $default-border-weight solid $black; }
-.bt-black { border-top: $default-border-weight solid $black; }
-.br-black { border-right: $default-border-weight solid $black; }
-.bb-black { border-bottom: $default-border-weight solid $black; }
-.bl-black { border-left: $default-border-weight solid $black; }
-
-.b-white { border: $default-border-weight solid $white; }
-.bt-white { border-top: $default-border-weight solid $white; }
-.br-white { border-right: $default-border-weight solid $white; }
-.bb-white { border-bottom: $default-border-weight solid $white; }
-.bl-white { border-left: $default-border-weight solid $white; }
-
-@each $grey in $greys {
-  $i: index($greys, $grey);
-
-  .b-#{$i} { border: $default-border-weight solid $grey; }
-  .bt-#{$i} { border-top: $default-border-weight solid $grey; }
-  .br-#{$i} { border-right: $default-border-weight solid $grey; }
-  .bb-#{$i} { border-bottom: $default-border-weight solid $grey; }
-  .bl-#{$i} { border-left: $default-border-weight solid $grey; }
-
-  .b-thick-#{$i} { border: $thick-border-weight solid $grey; }
-  .bt-thick-#{$i} { border-top: $thick-border-weight solid $grey; }
-  .br-thick-#{$i} { border-right: $thick-border-weight solid $grey; }
-  .bb-thick-#{$i} { border-bottom: $thick-border-weight solid $grey; }
-  .bl-thick-#{$i} { border-left: $thick-border-weight solid $grey; }
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decent-scss",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A functional CSS, f(css), framework for building anything on the web – works best with modular development",
   "scripts": {
     "start": "brunch watch --server",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "mocha": "mocha test/decent",
     "test": "brunch build && npm run mocha && npm run karma"
   },
+  "pre-commit": [
+    "test"
+  ],
   "devDependencies": {
     "auto-reload-brunch": "^2.7.1",
     "brunch": "^2.10.9",
@@ -25,6 +28,7 @@
     "karma-mocha-reporter": "^2.2.3",
     "karma-webpack": "^2.0.3",
     "mocha": "^3.2.0",
+    "pre-commit": "^1.2.2",
     "sass-brunch": "^2.10.4",
     "sass-lint-brunch": "^1.1.0",
     "style-loader": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mocha": "mocha test/decent",
     "test": "brunch build && npm run mocha && npm run karma"
   },
-  "pre-commit": [
+  "pre-push": [
     "test"
   ],
   "devDependencies": {
@@ -29,6 +29,7 @@
     "karma-webpack": "^2.0.3",
     "mocha": "^3.2.0",
     "pre-commit": "^1.2.2",
+    "pre-push": "^0.1.1",
     "sass-brunch": "^2.10.4",
     "sass-lint-brunch": "^1.1.0",
     "style-loader": "^0.16.1",

--- a/test/color.spec.js
+++ b/test/color.spec.js
@@ -1,0 +1,89 @@
+var addElement = require('./util/add-element')
+
+describe('color', () => {
+  var div = addElement('div')
+
+  it('should set primary text color', function () {
+    div.className = 'c-primary'
+    expect(div.computedStyle.color).to.equal('rgb(13, 13, 242)')
+  })
+
+  it('should set primary alt text color', function () {
+    div.className = 'c-primary-alt'
+    expect(div.computedStyle.color).to.equal('rgb(10, 10, 194)')
+  })
+
+  it('should set primary alt 2 text color', function () {
+    div.className = 'c-primary-alt-2'
+    expect(div.computedStyle.color).to.equal('rgb(8, 8, 145)')
+  })
+
+  it('should set success text color', function () {
+    div.className = 'c-success'
+    expect(div.computedStyle.color).to.equal('rgb(13, 242, 20)')
+  })
+
+  it('should set success alt text color', function () {
+    div.className = 'c-success-alt'
+    expect(div.computedStyle.color).to.equal('rgb(10, 194, 16)')
+  })
+
+  it('should set primary background color', function () {
+    div.className = 'cbg-primary'
+    expect(div.computedStyle.backgroundColor).to.equal('rgb(13, 13, 242)')
+  })
+
+  it('should set primary alt background color', function () {
+    div.className = 'cbg-primary-alt'
+    expect(div.computedStyle.backgroundColor).to.equal('rgb(10, 10, 194)')
+  })
+
+  it('should set primary alt 2 background color', function () {
+    div.className = 'cbg-primary-alt-2'
+    expect(div.computedStyle.backgroundColor).to.equal('rgb(8, 8, 145)')
+  })
+
+  it('should set success background color', function () {
+    div.className = 'cbg-success'
+    expect(div.computedStyle.backgroundColor).to.equal('rgb(13, 242, 20)')
+  })
+
+  it('should set success alt background color', function () {
+    div.className = 'cbg-success-alt'
+    expect(div.computedStyle.backgroundColor).to.equal('rgb(10, 194, 16)')
+  })
+
+  it('should set black text', function () {
+    div.className = 'cg-black'
+    expect(div.computedStyle.color).to.equal('rgb(3, 3, 3)')
+  })
+
+  it('should set white text', function () {
+    div.className = 'cg-white'
+    expect(div.computedStyle.color).to.equal('rgb(252, 252, 252)')
+  })
+
+  it('should set text greys', function () {
+    div.className = 'cg-5'
+    expect(div.computedStyle.color).to.equal('rgb(125, 125, 130)')
+  })
+
+  it('should set black background', function () {
+    div.className = 'cbgg-black'
+    expect(div.computedStyle.backgroundColor).to.equal('rgb(3, 3, 3)')
+  })
+
+  it('should set white background', function () {
+    div.className = 'cbgg-white'
+    expect(div.computedStyle.backgroundColor).to.equal('rgb(252, 252, 252)')
+  })
+
+  it('should set background greys', function () {
+    div.className = 'cbgg-5'
+    expect(div.computedStyle.backgroundColor).to.equal('rgb(125, 125, 130)')
+  })
+
+})
+
+// Sources:
+// 1. Basscss (https://github.com/basscss/basscss/blob/master/test/test.js)

--- a/util/_defaults.scss
+++ b/util/_defaults.scss
@@ -75,55 +75,42 @@ $typesets: (
 $container-width: 80rem !default;
 $columns: 12 !default;
 
-
+// Colorsets
 $colors: (
   'primary': (
-    'default': hsl(27, 100, 53),
-    'alt':     hsl(27, 100, 63),
-    'alt-2':   hsl(27, 100, 73),
-    'alt-3':   hsl(27, 100, 83)
+    'default':  hsl(240, 90, 50),
+    'alt':      hsl(240, 90, 40),
+    'alt-2':    hsl(240, 90, 30)
+  ),
+  'secondary': (
+    'default':  hsl(27, 100, 53),
+    'alt':      hsl(27, 100, 43),
+  ),
+  'success': (
+    'default':  hsl(122, 90, 50),
+    'alt':      hsl(122, 90, 40),
+    'alt-2':    hsl(122, 90, 30)
+  ),
+  'error': (
+    'default':  hsl(0, 90, 50),
+    'alt':      hsl(0, 90, 40),
+    'alt-2':    hsl(0, 90, 30),
   )
 ) !default;
 
+// Greyscale
 $greyscale: (
-  'black': #010101,
-  'white': #fefefe
+  'black': hsl(240, 1, 1),
+  '1':     hsl(240, 4, 10),
+  '2':     hsl(240, 3, 24),
+  '3':     hsl(240, 3, 30),
+  '4':     hsl(240, 2, 40),
+  '5':     hsl(240, 2, 50),
+  '6':     hsl(240, 2, 84),
+  '7':     hsl(240, 1, 92),
+  '8':     hsl(240, 1, 96),
+  'white': hsl(240, 0, 99)
 ) !default;
-
-// Colors
-$color-primary:     hsl(27, 100, 53)
-                    hsl(27, 100, 63)
-                    hsl(27, 100, 73)
-                    hsl(27, 100, 83);
-
-$color-secondary:   hsl(210, 29, 29)
-                    hsl(210, 29, 39)
-                    hsl(210, 29, 49) !default;
-
-$color-error:       hsl(6, 78, 57)
-                    hsl(6, 78, 67)
-                    hsl(6, 78, 77) !default;
-
-$color-warning:     hsl(37, 90, 50)
-                    hsl(37, 90, 60)
-                    hsl(37, 90, 70) !default;
-
-$color-success:     hsl(145, 63, 52)
-                    hsl(145, 63, 62)
-                    hsl(145, 63, 72) !default;
-
-$black:             #000 !default;
-$white:             #fff !default;
-$greys:             hsl(27, 1, 10)
-                    hsl(27, 1, 20)
-                    hsl(27, 1, 30)
-                    hsl(27, 1, 40)
-                    hsl(27, 1, 50)
-                    hsl(27, 1, 60)
-                    hsl(27, 1, 70)
-                    hsl(27, 1, 80)
-                    hsl(27, 1, 90)
-                    hsl(27, 1, 95) !default;
 
 // Modular Scale
 $modular-scale: (

--- a/util/_defaults.scss
+++ b/util/_defaults.scss
@@ -76,7 +76,7 @@ $container-width: 80rem !default;
 $columns: 12 !default;
 
 // Colorsets
-$colors: (
+$colorsets: (
   'primary': (
     'default':  hsl(240, 90, 50),
     'alt':      hsl(240, 90, 40),

--- a/util/_mixins.scss
+++ b/util/_mixins.scss
@@ -61,21 +61,36 @@
   }
 }
 
-@mixin build-colors($colorset, $name) {
-  @each $shade in $colorset {
-    $i: index($colorset, $shade)-1;
+@mixin build-colors($colors) {
+  @each $key, $shades in $colors {
+    @each $shade, $value in $shades {
+      $class: '';
 
-    @if $i == 0 {
-      .c-#{$name} { color: $shade; }
-      .cbg-#{$name} { background-color: $shade; }
+      @if $shade == 'default' {
+        $class: #{$key};
+      }
+      @else {
+        $class: #{$key}-#{$shade};
+      }
+
+      .c-#{$class} {
+        color: $value;
+      }
+
+      .cbg-#{$class} {
+        background-color: $value;
+      }
     }
-    @if $i == 1 {
-      .c-#{$name}-alt { color: $shade; }
-      .cbg-#{$name}-alt { background-color: $shade; }
+  }
+};
+
+@mixin build-greyscale($greyscale) {
+  @each $key, $value in $greyscale {
+    .cg-#{$key} {
+      color: $value;
     }
-    @else {
-      .c-#{$name}-alt-#{$i)} { color: $shade; }
-      .cbg-#{$name}-alt-#{$i)} { background-color: $shade; }
+    .cbgg-#{$key} {
+      background-color: $value;
     }
   }
 }


### PR DESCRIPTION
This makes decent even less opinionated and more flexible!

Colorsets can be written as a map, so say you want to add another set called `brand`, you can completely rewrite the default set or merge a map with `brand` into the default `$colorsets` map.

```
$colorsets: (
  'primary': (
    'default':  hsl(240, 90, 50),
    'alt':      hsl(240, 90, 40),
    'alt-2':    hsl(240, 90, 30)
  ),
  'secondary': (
    'default':  hsl(27, 100, 53),
    'alt':      hsl(27, 100, 43),
  ),
  'success': (
    'default':  hsl(122, 90, 50),
    'alt':      hsl(122, 90, 40),
    'alt-2':    hsl(122, 90, 30)
  ),
  'error': (
    'default':  hsl(0, 90, 50),
    'alt':      hsl(0, 90, 40),
    'alt-2':    hsl(0, 90, 30),
  )
) !default;
```

This will give `.c-` and `.cbgg-` classes for each set. Default classes output without a key, ie `cbg-primary`, while the others will append the key, ie `cbg-primary-alt`.

The greyscale is also written similar, but can only be made up of one set.

```
$greyscale: (
  'black': hsl(240, 1, 1),
  '1':     hsl(240, 4, 10),
  '2':     hsl(240, 3, 24),
  '3':     hsl(240, 3, 30),
  '4':     hsl(240, 2, 40),
  '5':     hsl(240, 2, 50),
  '6':     hsl(240, 2, 84),
  '7':     hsl(240, 1, 92),
  '8':     hsl(240, 1, 96),
  'white': hsl(240, 0, 99)
) !default;
```

You can access greys with `.cg-` and `.cbgg-`.